### PR TITLE
Update interacted summary to add time in result extensions

### DIFF
--- a/statement_data_model.md
+++ b/statement_data_model.md
@@ -630,10 +630,18 @@ The value must be RFC 5646, e.g en, en-US, etc
 <th align="left">Interacted</th>
 <td>
 
+<b>Context Extensions</b>
 <ul>
 <li>Context Extensions for which the value has changed during interaction MUST be included</li>
 </ul>
 </td>
+<br>
+
+
+<b>Result Extensions</b>
+<ul>
+<li>Time</li>
+</ul>
 
 <td>
 <b>Context Extensions


### PR DESCRIPTION
In the time documentation, it is indicated to must use it with the
interacted verb but this information is missing in the summary of
extensions usage and can lead to confusion.